### PR TITLE
Added publish a release workflow and bumped version.

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,42 @@
+name: Publish a release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.2
+      - uses: actions/setup-node@v1.4.3
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.2
+      - uses: actions/setup-node@v1.4.3
+        with:
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.PUBLISH_NPM_TOKEN}}
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.2
+      - uses: actions/setup-node@v1.4.3
+        with:
+          registry-url: https://npm.pkg.github.com/
+          scope: '@ContaSystemer'
+      - run: npm ci
+      - run: echo registry=https://npm.pkg.github.com/ContaSystemer >> .npmrc
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.PUBLISH_GITHUB_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ContaSystemer/angularjs-assert",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "AngularJS assert module provides a set of assertion functions for verifying invariants.",
     "main": "index.js",
     "scripts": {
@@ -21,9 +21,6 @@
         "url": "https://github.com/ContaSystemer/angularjs-assert/issues"
     },
     "homepage": "https://github.com/ContaSystemer/angularjs-assert#readme",
-    "publishConfig": {
-        "registry": "https://npm.pkg.github.com/"
-    },
     "devDependencies": {
         "angular": "^1.7.9",
         "angular-mocks": "^1.7.9",


### PR DESCRIPTION
Now after release tag is created the workflow will automatically publish it to GitHub and NPM registries.